### PR TITLE
Fix ping timeout handling and ignore automake files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# automake related
+.dirstamp
+
 # Compiled Object files
 *.slo
 *.lo


### PR DESCRIPTION
libcec-daemon kept terminating on suspend/resume.  The CEC_ALERT_CONNECTION_LOST alert happens after three failed pings in libcec but libcec-daemon stops running after one failure.  This change makes libcec-daemon try three times as well and the problem is solved since libcec-daemon handles the alert.

DEBUG - Main::onCecLogMessage(103044 [E]failed to ping the adapter 3 times in a row. closing the connection.)
ERROR - Main::onCecAlert(alert=1)

Also the .dirstamp file created by automake is added to .gitignore.

Tested on ubuntu 14.04 LTS with libCEC version 2.1.4
